### PR TITLE
Adding contributor list on webpage code

### DIFF
--- a/contributor.html
+++ b/contributor.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+  <title>Contributors</title>
+  <style>
+    .contributors {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+      padding: 1rem;
+    }
+    .contributor {
+      text-align: center;
+      font-size: 14px;
+    }
+    .contributor img {
+      border-radius: 50%;
+      width: 80px;
+      height: 80px;
+      display: block;
+      margin-bottom: 5px;
+    }
+  </style>
+</head>
+<body>
+  <h2>Contributors</h2>
+  <div id="contributors" class="contributors"></div>
+
+  <script>
+    const owner = "Tevin-vrouzer18"; // 👈 Replace with your GitHub username
+    const repo = "forked-simple-contribution";      // 👈 Replace with your repository name
+    fetch(`https://api.github.com/repos/${owner}/${repo}/contributors`)
+      .then(response => response.json())
+      .then(contributors => {
+        const container = document.getElementById("contributors");
+
+        contributors.forEach(user => {
+          const div = document.createElement("div");
+          div.className = "contributor";
+
+          div.innerHTML = `
+            <a href="${user.html_url}" target="_blank">
+              <img src="${user.avatar_url}" alt="${user.login}" />
+              <span>${user.login}</span>
+            </a>
+          `;
+
+          container.appendChild(div);
+        });
+      })
+      .catch(error => {
+        console.error("Error fetching contributors:", error);
+      });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

This pull request adds a standalone script that fetches and displays the list of contributors for this GitHub repository using the GitHub API.

## What's Included

- A new HTML/JS file ( contributors.html) that:
  - Fetches contributor data from the GitHub API
  - Displays avatars and usernames with links to GitHub profiles
- Responsive styling to show contributors in a grid format

## Usage

To view the contributor list, simply open the new HTML file in a browser.

### Preview Features

- Contributor avatar image
- GitHub username
- Link to contributor’s GitHub profile

## Benefits

- Keeps contributor display logic separate from main `index.html`
- Easy to integrate into other pages as needed
- Lightweight and API-based — always shows up-to-date contributors

## Future Improvements

- Add loading states/error messages
- Make the component embeddable in other pages (`<iframe>` or module)
- Handle API rate-limiting with token support if needed

## Notes

- This version only works for **public repos**
- To make it work with private repos or high-traffic sites, GitHub API tokens may be needed

---

