### PR TITLE
Added Antonella Muñoz card info

### DIFF
--- a/cardDetails.json
+++ b/cardDetails.json
@@ -12,6 +12,14 @@
       "email": "mailto:youremail@gmail.com"
     },
     {
+      "name": "Antonella Muñoz",
+      "profession": "Digital Marketer - Aspiring Full-Stack Developer",
+      "quote": "\"Life begins at the end of your comfort zone\"</br> - Said By Neale Donald Walsch",
+      "github": "https://github.com/antonellamunoz1989",
+      "linkedin": "https://www.linkedin.com/in/antonella-m-723b2014a/",
+      "email": "mailto:youremail@gmail.com"
+    },
+    {
       "name": "carlos saenz",
       "profession": "Front-end Developer",
       "quote": "\"love and dedication\"</br> - Said By Me",


### PR DESCRIPTION
This pull request adds my contributor card to the simple-contribution repository. My card includes my name, surname, current profession, aspiring profession, favourite quote along with its author, and social links (LinkedIn and GitHub). The card has been tested and is visible in the browser.

<img width="1440" height="900" alt="Screenshot 2026-03-30 at 19 21 24" src="https://github.com/user-attachments/assets/b2ce86c0-b755-48c1-a362-545596ff564d" />
